### PR TITLE
Fix detail view for series blog

### DIFF
--- a/src/views/PostView.vue
+++ b/src/views/PostView.vue
@@ -52,14 +52,13 @@ watch(currentRoute, () => {
 })
 
 const loadMarkdown = () => {
-  let title
+  let sTitle
   if (currentRoute.value.params.series) {
-    title = decodeURIComponent(currentRoute.value.params.series.toString())
-  } else {
-    title = decodeURIComponent(currentRoute.value.params.name.toString())
+    sTitle = decodeURIComponent(currentRoute.value.params.series.toString())
   }
+  const title = decodeURIComponent(currentRoute.value.params.name.toString())
 
-  const module = modules.value.find(item => item.meta.title === title)
+  const module = modules.value.find(item => item.meta.title === title && item.meta.seriesTitle === sTitle)
 
   peekData.value = module.meta
   content.value = DOMPurify.sanitize(getContentHtml(module.raw))


### PR DESCRIPTION
For the series, we need to get it from the `modules` with the name combination of `SeriesTitle/BlogName`

Fixes: https://github.com/JankariTech/blog/issues/31

---
Signed-off-by: PKiran <kiranparajuli589@gmail.com>
