### PR TITLE
Scroll to top on detail view navigation

### DIFF
--- a/src/router.js
+++ b/src/router.js
@@ -36,7 +36,10 @@ const routes = [
 const router = createRouter({
   // https://router.vuejs.org/guide/essentials/history-mode.html
   history: createWebHashHistory(),
-  routes // short for `routes: routes`
+  routes, // short for `routes: routes`
+  scrollBehavior (to, from, savedPosition) {
+    return { top: savedPosition?.top || 0 }
+  }
 })
 
 export default router


### PR DESCRIPTION
### Description
There are two cases of browser page nav.
- moving from one page to another
- remaining on the same page just reload/refresh

For the first case, the scroll position should always be at the top. For new page navigation, we should not remember any scroll position rather the browser should start from the top

For the second case, we can remember the scroll position and show the user/reader to the same scroll location he was when the reload|refresh occurred.

### Related
Fixes https://github.com/JankariTech/blog/issues/8

---
Signed-off-by: PKiran <kiranparajuli589@gmail.com>
