### PR TITLE
Fix table of content scroll to heading

### DIFF
--- a/src/helpers/markdown.js
+++ b/src/helpers/markdown.js
@@ -1,6 +1,11 @@
 import { marked } from "marked"
 import useMarkdown from "@/composables/markdown"
 
+marked.setOptions({
+  sanitize: true,
+  headerIds: true
+})
+
 export const getFileName = (sourcePath) => {
   return sourcePath.split("/src/assets/").at(-1).split(".md")[0]
 }
@@ -14,7 +19,6 @@ export const readAssets = () => {
     "/src/assets/**/*.md",
     { as: "raw" }
   )
-
   return {
     fileModules
   }
@@ -78,12 +82,12 @@ export const getPeekData = () => {
 }
 
 export const getContentHtml = (source) => {
-  const tokens = marked.lexer(source, { sanitize: true })
-  return marked.parser(tokens.slice(3), { sanitize: true })
+  const tokens = marked.lexer(source)
+  return marked.parser(tokens.slice(3))
 }
 
 export const getTableOfContent = (source) => {
-  const lexer = marked.lexer(source, { sanitize: true })
-  // get all heading tokens
-  return lexer.filter(token => token.type === "heading")
+  const tokens = marked.lexer(source)
+  // return all heading tokens
+  return tokens.filter(token => token.type === "heading")
 }

--- a/src/views/PostView.vue
+++ b/src/views/PostView.vue
@@ -20,7 +20,7 @@
           :key="index"
           class="blog--sidebar--item"
           :class="`heading-${item.depth}`"
-          @click="scrollToHeading(item.text)"
+          @click="scrollToHeading(item.text, item.depth)"
         >
           {{ item.text }}
         </div>
@@ -67,21 +67,21 @@ const loadMarkdown = () => {
   document.title = `Blog | ${peekData.value.title}`
 }
 
-const scrollToHeading = (headingText) => {
-  const punctuation = "!\"#$%&'()*+,-./:;<=>?@[\\]^_`{|}~"
-  const regex = new RegExp("[" + punctuation + "]", "g")
-
-  const id = headingText
-    .toLowerCase()
-    .replace(regex, "")
-    .split(" ")
-    .join("-")
-
-  const heading = document.querySelector(`.blog--content #${id}`)
-  heading.scrollIntoView({
-    behavior: "smooth",
-    block: "center"
-  })
+const scrollToHeading = (headingText, headingDepth) => {
+  const xpath = `//h${headingDepth}[contains(text(), '${headingText.trim()}')]`
+  const heading = document.evaluate(
+    xpath,
+    document,
+    null,
+    XPathResult.FIRST_ORDERED_NODE_TYPE,
+    null
+  ).singleNodeValue
+  if (heading) {
+    heading.scrollIntoView({
+      behavior: "smooth",
+      block: "center"
+    })
+  }
 }
 </script>
 <style lang="scss">


### PR DESCRIPTION
## Description
The problem is sometime we can have heading like:
```
### 1. Honesty
```
in the markdown file. Now the `marked` library adds `id` to the heading class with respect to the heading content.
So, for the above heading id is set as `1-honesty` with is sadly an invalid css selector. Numbers cannot be in start of the css selector.

To cope with this problem, we can use the xpath and search by content instead.

If we find the heading of targetted depth with the targetted content, then we find the match and can scroll to that element.


---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
