### PR TITLE
[feat] save font and theme for the next browse

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -17,7 +17,7 @@
   </div>
 </template>
 <script setup>
-import { watch, onMounted, ref, computed } from "vue"
+import { watch, onMounted, ref, computed, onBeforeMount } from "vue"
 
 import TheAppBar from "./components/TheAppBar"
 import TheFooter from "./components/TheFooter"
@@ -25,8 +25,10 @@ import useTheme from "./composables/theme"
 import useMarkdown from "./composables/markdown"
 import { readAssets, getPeekInfoForModules } from "./helpers/markdown"
 import { useRouter } from "vue-router"
+import { Storage } from "./helpers/storage"
+import { FONT_MAP } from "./helpers/constants"
 
-const { dark } = useTheme()
+const { dark, setFont, setDark, font } = useTheme()
 const { setModules } = useMarkdown()
 const { currentRoute } = useRouter()
 
@@ -43,6 +45,19 @@ const scrollButtonVisibility = ref(false)
 onMounted(() => {
   window.addEventListener("scroll", onScroll)
 })
+
+onBeforeMount(() => {
+  getThemeAndFont()
+})
+
+const getThemeAndFont = () => {
+  const savedFontName = Storage.getFont()
+  const fontValue = FONT_MAP.find(item => item.name === savedFontName)?.class || FONT_MAP[0].class
+
+  setFont(fontValue)
+  setDark(Storage.getTheme() === "dark")
+  document.body.classList.add(font.value)
+}
 
 const onScroll = (e) => {
   if (typeof window === "undefined") return

--- a/src/components/TheAppBar.vue
+++ b/src/components/TheAppBar.vue
@@ -1,7 +1,11 @@
 <template>
   <nav class="appbar sharp-border">
     <a href="/">
-      <img class="appbar--logo" :src="dark ? jtLogoWithNameDark: jtLogoWithName" alt="" width="200" >
+      <img width="200"
+        class="appbar--logo"
+        alt="JankariTech Logo"
+        :src="dark ? logoWithNameDark: logoWithName"
+      >
     </a>
     <div class="appbar--actions">
       <button class="appbar--icon icon-button toggle-theme" @click="toggleTheme()">
@@ -34,17 +38,17 @@
   </nav>
 </template>
 <script setup>
-import { watch, onBeforeMount } from "vue"
+import { watch } from "vue"
 import useTheme from "../composables/theme"
 import { FONT_MAP } from "../helpers/constants"
 import getImageUrl from "../helpers/images"
 import DropMenu from "./DropMenu.vue"
 import { Storage } from "../helpers/storage"
 
-const { dark, toggle, font, setFont, setDark } = useTheme()
+const { dark, toggle, font, setFont } = useTheme()
 
-const jtLogoWithName = getImageUrl("../imgs/jt_logo_with_name.png")
-const jtLogoWithNameDark = getImageUrl("../imgs/jt_logo_with_name_dark.png")
+const logoWithName = getImageUrl("../imgs/jt_logo_with_name.png")
+const logoWithNameDark = getImageUrl("../imgs/jt_logo_with_name_dark.png")
 
 watch(font, () => {
   document.body.classList.remove(...FONT_MAP.map(item => item.class))
@@ -56,15 +60,6 @@ const toggleTheme = () => {
   toggle()
   Storage.saveTheme(dark.value ? "dark" : "light")
 }
-
-onBeforeMount(() => {
-  const savedFontName = Storage.getFont()
-  const fontValue = FONT_MAP.find(item => item.name === savedFontName)?.class || FONT_MAP[0].class
-
-  setFont(fontValue)
-  setDark(Storage.getTheme() === "dark")
-  document.body.classList.add(font.value)
-})
 
 const toGithub = () => {
   window.open("https://github.com/JankariTech/blog", "_blank")

--- a/src/components/TheAppBar.vue
+++ b/src/components/TheAppBar.vue
@@ -4,7 +4,7 @@
       <img class="appbar--logo" :src="dark ? jtLogoWithNameDark: jtLogoWithName" alt="" width="200" >
     </a>
     <div class="appbar--actions">
-      <button class="appbar--icon icon-button toggle-theme" @click="toggle">
+      <button class="appbar--icon icon-button toggle-theme" @click="toggleTheme()">
         <mdi-brightness-6 class="one-rem"/>
       </button>
       <DropMenu>
@@ -34,27 +34,35 @@
   </nav>
 </template>
 <script setup>
-import DropMenu from "./DropMenu.vue"
 import { watch, onBeforeMount } from "vue"
-import useTheme from "@/composables/theme"
+import useTheme from "../composables/theme"
+import { FONT_MAP } from "../helpers/constants"
+import getImageUrl from "../helpers/images"
+import DropMenu from "./DropMenu.vue"
+import { Storage } from "../helpers/storage"
 
-const { dark, toggle, font, setFont } = useTheme()
+const { dark, toggle, font, setFont, setDark } = useTheme()
 
-const jtLogoWithName = new URL("../imgs/jt_logo_with_name.png", import.meta.url).href
-const jtLogoWithNameDark = new URL("../imgs/jt_logo_with_name_dark.png", import.meta.url).href
-
-const FONT_MAP = [
-  { name: "Lato", class: "font-lato" },
-  { name: "Roboto", class: "font-roboto" },
-  { name: "Poppins", class: "font-poppins" },
-  { name: "Open Sans", class: "font-open-sans" }
-]
+const jtLogoWithName = getImageUrl("../imgs/jt_logo_with_name.png")
+const jtLogoWithNameDark = getImageUrl("../imgs/jt_logo_with_name_dark.png")
 
 watch(font, () => {
   document.body.classList.remove(...FONT_MAP.map(item => item.class))
   document.body.classList.add(font.value)
+  Storage.saveFont(FONT_MAP.find(item => item.class === font.value).name)
 })
+
+const toggleTheme = () => {
+  toggle()
+  Storage.saveTheme(dark.value ? "dark" : "light")
+}
+
 onBeforeMount(() => {
+  const savedFontName = Storage.getFont()
+  const fontValue = FONT_MAP.find(item => item.name === savedFontName)?.class || FONT_MAP[0].class
+
+  setFont(fontValue)
+  setDark(Storage.getTheme() === "dark")
   document.body.classList.add(font.value)
 })
 

--- a/src/composables/theme.js
+++ b/src/composables/theme.js
@@ -1,11 +1,11 @@
-import { useThemeStore } from "@/store/theme"
+import { useThemeStore } from "../store/theme"
 import { storeToRefs } from "pinia"
 
 export default function useTheme () {
   const store = useThemeStore()
   const { dark, font } = storeToRefs(store)
-  const { toggle, setFont } = store
+  const { toggle, setFont, setDark } = store
   return {
-    dark, font, toggle, setFont
+    dark, font, toggle, setFont, setDark
   }
 }

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -4,3 +4,19 @@ export const FONT_MAP = [
   { name: "Poppins", class: "font-poppins" },
   { name: "Open Sans", class: "font-open-sans" }
 ]
+
+export const THEME_ARRAY = ["light", "dark"]
+
+export const DEFAULT_FONT = FONT_MAP[0].name
+
+export const DEFAULT_THEME = THEME_ARRAY[0]
+
+export const SORT_OPTIONS = [
+  { key: "alpha", label: "Alphabetically" },
+  { key: "date", label: "Date Created" }
+]
+
+export const FILTER_OPTIONS = [
+  { key: "author", label: "Author" },
+  { key: "tag", label: "Tags" }
+]

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -1,0 +1,6 @@
+export const FONT_MAP = [
+  { name: "Lato", class: "font-lato" },
+  { name: "Roboto", class: "font-roboto" },
+  { name: "Poppins", class: "font-poppins" },
+  { name: "Open Sans", class: "font-open-sans" }
+]

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -1,0 +1,27 @@
+import { FONT_MAP } from "./constants"
+
+export class Storage {
+  static saveTheme (theme) {
+    if (["light", "dark"].includes(theme)) {
+      localStorage.setItem("theme", theme)
+    } else {
+      console.error("Invalid theme")
+    }
+  }
+
+  static getTheme () {
+    return localStorage.getItem("theme") || "light"
+  }
+
+  static saveFont (font) {
+    if (FONT_MAP.map(font => font.name).includes(font)) {
+      localStorage.setItem("font", font)
+    } else {
+      console.error("Invalid font")
+    }
+  }
+
+  static getFont () {
+    return localStorage.getItem("font") || "Lato"
+  }
+}

--- a/src/helpers/storage.js
+++ b/src/helpers/storage.js
@@ -1,11 +1,13 @@
-import { FONT_MAP } from "./constants"
+import { DEFAULT_FONT, DEFAULT_THEME, FONT_MAP, THEME_ARRAY } from "./constants"
 
 export class Storage {
   static saveTheme (theme) {
-    if (["light", "dark"].includes(theme)) {
+    if (THEME_ARRAY.includes(theme)) {
       localStorage.setItem("theme", theme)
     } else {
-      console.error("Invalid theme")
+      console.error("Invalid theme is provided.")
+      // fallback to default theme
+      localStorage.setItem("theme", DEFAULT_THEME)
     }
   }
 
@@ -17,11 +19,13 @@ export class Storage {
     if (FONT_MAP.map(font => font.name).includes(font)) {
       localStorage.setItem("font", font)
     } else {
-      console.error("Invalid font")
+      console.error("Invalid font is provided.")
+      // fallback to default font
+      localStorage.setItem("font", DEFAULT_FONT)
     }
   }
 
   static getFont () {
-    return localStorage.getItem("font") || "Lato"
+    return localStorage.getItem("font") || DEFAULT_FONT
   }
 }

--- a/src/store/theme.js
+++ b/src/store/theme.js
@@ -11,6 +11,9 @@ export const useThemeStore = defineStore("theme", {
     },
     setFont (font) {
       this.font = font
+    },
+    setDark (isDark) {
+      this.dark = isDark
     }
   }
 })

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -33,12 +33,12 @@
           <button class="icon-button" title="Filter"
             :class="{ 'filtering' : $route.name === 'Filter' }"
           >
-            <mdi-filter class="one-rem" />
+            <mdi-filter class="one-rem"/>
           </button>
         </template>
         <template #drop>
           <div
-            v-for="item in filterItems"
+            v-for="item in FILTER_OPTIONS"
             :key="item.key"
             class="menu-drop-item" @click="setFilterKey(item.key)"
             :class="{'item-active': $route.params.filterBy === item.key}"
@@ -59,7 +59,7 @@
 
         <template #drop>
           <div
-            v-for="item in sortItems"
+            v-for="item in SORT_OPTIONS"
             :key="item.key"
             class="menu-drop-item"
             @click="setSortKey(item.key)"
@@ -87,7 +87,7 @@
       <div v-if="peekData.length === 0"
         class="home-view--no-results"
       >
-        <div class="message">Sorry, no results found for "{{search}}"</div>
+        <div class="message">Sorry, no results found for "{{ search }}"</div>
         <button @click="clearSearch">Reset Search</button>
       </div>
     </div>
@@ -99,6 +99,8 @@ import { useRouter } from "vue-router"
 import BlogPeek from "../components/BlogPeek"
 import DropMenu from "../components/DropMenu"
 import { getPeekData } from "../helpers/markdown"
+import getImageUrl from "../helpers/images"
+import { SORT_OPTIONS, FILTER_OPTIONS } from "../helpers/constants"
 
 const { currentRoute, push } = useRouter()
 
@@ -107,28 +109,6 @@ const search = ref("")
 const loading = ref(false)
 const filterBy = ref(null)
 const sortBy = ref(null)
-
-const sortItems = [
-  {
-    key: "alpha",
-    label: "Alphabetically"
-  },
-  {
-    key: "date",
-    label: "Date Created"
-  }
-]
-
-const filterItems = [
-  {
-    key: "author",
-    label: "Author"
-  },
-  {
-    key: "tag",
-    label: "Tags"
-  }
-]
 
 onMounted(async () => {
   init()
@@ -143,7 +123,7 @@ const init = () => {
   loading.value = false
 }
 
-const loadingImage = new URL("../imgs/loading.png", import.meta.url).href
+const loadingImage = getImageUrl("../imgs/loading.png")
 
 const goToBlogDetail = (item) => {
   const series = item.seriesTitle


### PR DESCRIPTION
### With this PR:

- save `theme` and `font` for the next browse (browser `localStorage` is used for the storage)
- set default theme as `light` and default font as `Lato`
- moved `constants` used through the code to a separate file
- some image usage optimizations
- Fixes: https://github.com/JankariTech/blog/issues/18

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
