### PR TITLE
Add 'inter' font and set as the default

### DIFF
--- a/src/assets/BDDInGo.md
+++ b/src/assets/BDDInGo.md
@@ -45,7 +45,7 @@ In the project folder we create a new file called `bs-to-ad-conversion.feature`.
 _Side note: there is always the discussion what is a "feature"? In our example: is the conversion in both directions one or two features? Is the error-handling a separate feature or a part of the conversion feature? If you are not sure, be practical and simply make sure the file does not get too long._
 
 We start the feature file with a very general description of the feature:
-```
+```gherkin
 Feature: convert dates from BS to AD using an API
   As an app-developer in Nepal
   I want to be able to send BS dates to an API endpoint and receive the corresponding AD dates
@@ -67,7 +67,7 @@ In every scenario your app might behave differently. If that specific behavior i
 
 In Gherkin we have to start the scenario description with the `Scenario:` keyword and a short free-text sentence:
 
-```
+```gherkin
   Scenario: converting a valid BS date
 
   Scenario: converting an invalid BS date
@@ -80,13 +80,13 @@ Now we want to describe the specific behavior of the app in that scenario. For t
 - **Then** - the desired observable outcome
 
 Additionally, there is **And**, if you have multiple of one of the above, you don't need to write
-```
+```gherkin
 When doing A
 When doing B
 ```
 
 but you can use `And` (it just sounds and reads nicer)
- ```
+ ```gherkin
  When doing A
  And doing B
  ```
@@ -135,7 +135,7 @@ We could stop there, but there is a great bonus-point: let's use these descripti
 For that we need software that interprets the Gherkin language and runs code that executes the tests. For Go there is the [godog package](https://github.com/DATA-DOG/godog).
 
 To install godog we fist have to create a simple `go.mod` file with the content
-```
+```golang
 module github.com/JankariTech/bsDateServer
 
 go 1.13
@@ -400,7 +400,7 @@ Here we simply get the status code and the result body and compare it with the e
 The regular-expression change in the `FeatureContext` just makes sure that we only accept decimal numbers in that step.
 
 Now the tests fail with:
-```
+```gherkin
 ...
   Scenario: converting a valid BS date # bs-to-ad-conversion.feature:6
     Then the HTTP-response code should be "200" # bs-to-ad-conversion.feature:8
@@ -458,7 +458,7 @@ index ae01ed0..06299b0 100644
 Basically: split the incoming string, send it to the `GoBikramSambat` lib and return the formatted result.
 
 And with that the first scenario passes:
-```
+```gherkin
 ...
   Scenario: converting a valid BS date                                    # bs-to-ad-conversion.feature:6
     When a "GET" request is sent to the endpoint "/ad-from-bs/2060-04-01" # bsdateServer_test.go:14 -> aRequestIsSentToTheEndpoint
@@ -521,7 +521,7 @@ index 3156498..16c48ab 100644
 In `main.go` we now spit out an Error if the conversion does not work and in the tests we trim the body, because `http.Error` likes to send an `\n` at the end of the body.
 
 Finally, the scenarios pass:
-```
+```gherkin
 Feature: convert dates from BS to AD using an API
   As an app-developer in Nepal
   I want to be able to send BS dates to an API endpoint and receive the corresponding AD dates

--- a/src/assets/BDDInGo_2_DE.md
+++ b/src/assets/BDDInGo_2_DE.md
@@ -16,7 +16,7 @@ Die Kommunikation und damit die Erfolgschancen der Entwicklung einer Anwendung z
 (Wie schon im ersten Artikel werde ich den Quellcode und die Feature-Dateien nicht übersetzen, sondern so zeigen, wie sie in [GitHub](https://github.com/JankariTech/bsDateServer) abgespeichert sind.)
 
 Nach ["Einstieg in BDD (Behavior-driven development)"](https://dev.to/jankaritech/einstieg-in-bdd-behavior-driven-development-1m8h) haben wir ein Feature-File, das so aussieht:
-```
+```gherkin
 Feature: convert dates from BS to AD using an API
   As an app-developer in Nepal
   I want to be able to send BS dates to an API endpoint and receive the corresponding AD dates
@@ -38,7 +38,7 @@ Um aus den Feature-Files automatische Tests zu machen, brauchen wir zunächst ei
 Solche Interpreter gibt es für die verschiedensten Programmiersprachen. In diesem Artikel demonstriere ich, wie es mit [godog package](https://github.com/cucumber/godog) für Go funktioniert.
 
 Um godog zu [installieren](https://github.com/cucumber/godog#install), müssen wir zunächst eine einfache `go.mod` Datei anlegen
-```
+```golang
 module github.com/JankariTech/bsDateServer
 
 go 1.13
@@ -51,7 +51,7 @@ Um mit `$GOPATH` arbeiten zu können, muss zusätzlich noch die Umgebungsvariabl
 (Die Versionsnummer `@v0.11.0` ist optional; ohne sie wird die neueste vorhandene Version installiert. Damit dieser Artikel aber länger verwendbar bleibt und ich ihn nicht ständig anpassen muss, gebe ich hier eine Versionsnummer an.)
 
 Jetzt können wir godog mit `$GOPATH/godog *.feature` ausführen. Die Ausgabe sollte in etwa so aussehen:
-```
+```gherkin
 Feature: convert dates from BS to AD using an API
   As an app-developer in Nepal
   I want to be able to send BS dates to an API endpoint and receive the corresponding AD dates
@@ -94,7 +94,7 @@ func InitializeScenario(ctx *godog.ScenarioContext) {
 
 Godog listet alle Szenarien, die wir ausführen wollen, und sagt uns, dass es keine Ahnung hat, was es machen soll. Das ist keine Überraschung - schließlich haben wir noch keine Test-Schritte implementiert. Um das zu tun, erstellen wir eine Datei mit dem Namen `bsdateServer_test.go` und dem Inhalt:
 
-```
+```go
 package main
 
 import (
@@ -124,7 +124,7 @@ Die `InitializeScenario` Funktion ist die Verbindung zwischen der menschenlesbar
 Aus `When a "GET" request is sent to the endpoint "/ad-from-bs/2060-04-01"` wird der Funktionsaufruf: `aRequestIsSentToTheEndpoint("GET", "/ad-from-bs/2060-04-01")`
 
 Wenn wir wieder `$GOPATH/godog *.feature` ausführen, sieht die Ausgabe schon anders aus:
-```
+```gherkin
 Feature: convert dates from BS to AD using an API
   As an app-developer in Nepal
   I want to be able to send BS dates to an API endpoint and receive the corresponding AD dates
@@ -190,7 +190,7 @@ Wir benutzen das `net/http` Go packet, um eine einfache HTTP Anfrage zu versende
 Randbemerkung: die `res` Variable ist außerhalb der Funktion definiert, weil wir auf sie noch von anderen Funktionen zugreifen müssen.
 
 Die Ausgabe von `$GOPATH/godog *.feature` ist jetzt:
-```
+```gherkin
 ...
   Scenario: converting a valid BS date                                    # bs-to-ad-conversion.feature:6
     When a "GET" request is sent to the endpoint "/ad-from-bs/2060-04-01" # bsdateServer_test.go:13 -> aRequestIsSentToTheEndpoint
@@ -204,7 +204,7 @@ Die Ausgabe von `$GOPATH/godog *.feature` ist jetzt:
 Die HTTP Anfrage, die der Test sendet, schlägt fehl, weil nichts auf dem entsprechenden Port lauscht. Ganz Ähnlich wie bei TDD (Test Driven Development) haben wir erst den Test gebaut (oder einen Teil davon), bevor die Software implementiert wurde.
 
 Deswegen implementieren wir jetzt einen minimal-Server, der praktisch nur den Port `10000` öffnet. Dafür kommt der folgende code in die Datei `main.go` und dann wird der Server mit `go run main.go` gestartet
-```
+```go
 package main
 
 import (
@@ -230,7 +230,7 @@ func main() {
 ```
 
 Wenn wir jetzt die Tests laufen lassen, während der Server läuft, sieht man, dass wir einen Schritt weiter gekommen sind:
-```
+```gherkin
   Scenario: converting a valid BS date                                    # bs-to-ad-conversion.feature:6
     When a "GET" request is sent to the endpoint "/ad-from-bs/2060-04-01" # bsdateServer_test.go:13 -> aRequestIsSentToTheEndpoint
     Then the HTTP-response code should be "200"                           # bsdateServer_test.go:27 -> theHTTPresponseCodeShouldBe
@@ -299,7 +299,7 @@ _Randnotiz: Es ist wichtig, gute Fehlermeldungen auszugeben. Das Ziel einer Fehl
 Die kleine Änderung in der Regular-Expression in `InitializeScenario` stellt sicher, dass nur Zahlen als HTTP Status Code akzeptiert werden.
 
 Die Ausgabe der Tests ist jetzt:
-```
+```feature
 ...
   Scenario: converting a valid BS date # bs-to-ad-conversion.feature:6
     Then the HTTP-response code should be "200" # bs-to-ad-conversion.feature:8
@@ -358,7 +358,7 @@ index ae01ed0..06299b0 100644
 Die Änderung ist eigentlich recht simpel: das BS Datum in Tag, Monat und Jahr aufspalten und es an die fertige `GoBikramSambat` Bibliothek übergeben. (Die Bibliothek wird mit `go get github.com/JankariTech/GoBikramSambat` installiert)
 
 Und damit funktioniert schon das erste Szenario:
-```
+```feature
 ...
   Scenario: converting a valid BS date                                    # bs-to-ad-conversion.feature:6
     When a "GET" request is sent to the endpoint "/ad-from-bs/2060-04-01" # bsdateServer_test.go:14 -> aRequestIsSentToTheEndpoint
@@ -421,7 +421,7 @@ index b731d6d..9871219 100644
 Sollte die Konvertierung nicht funktionieren, wird jetzt in `main.go` ein Fehler ausgegeben. In den Tests benutzen wir `TrimSpace`, weil `http.Error` ein `\n` an den Fehlertext hängt.
 
 Nun sollten beide Szenarien grün sein:
-```
+```feature
 Feature: convert dates from BS to AD using an API
   As an app-developer in Nepal
   I want to be able to send BS dates to an API endpoint and receive the corresponding AD dates

--- a/src/assets/LoadTestingWithK6/k6-01.md
+++ b/src/assets/LoadTestingWithK6/k6-01.md
@@ -16,7 +16,7 @@ Now, how do we determine how many users your backend infrastructure can handle?
 
 To answer that, and other performance questions, we have a couple of great performance-testing tools available out there. One of them is [k6](https://k6.io/)
 
-### what is k6?
+### What is k6?
 k6 is a free and open-source load testing tool written in Go programming language. But you don't need to know `Go` to write tests using k6.
 If you are familiar with the basics of ES2015/ES6, you won't have any headache writing k6 tests.
 
@@ -25,7 +25,7 @@ To install k6 in your local machine follow the instructions provided here https:
 
 I am using ubuntu `18.04` but even if you are using another operating system you can follow along.
 
-### Your first test:
+### Your first test
 
 k6 is based on the concept of `virtual users` (VUs) that is supposed to simulate the real-time traffic and then execute the script in parallel.
 

--- a/src/components/BlogPeek.vue
+++ b/src/components/BlogPeek.vue
@@ -46,17 +46,15 @@
       </div>
     </div>
     <div class="blog-peek--content">
-      <component class="blog-title"
-        :is="detailView ? 'h1' : 'h3'"
-      >
+      <div class="blog-title">
         {{ title }}
-      </component>
+      </div>
       <div class="tags">
         <span v-for="(item, index) in tags"
           :key="index"
           class="tag-item"
         >
-          #{{item}}
+          #&nbsp;{{item}}
         </span>
       </div>
     </div>

--- a/src/components/detail/ContentData.vue
+++ b/src/components/detail/ContentData.vue
@@ -21,8 +21,8 @@ defineProps({
   }
 
   p {
-    font-size: 1rem;
-    line-height: 1.6rem;
+    text-align: justify;
+    text-justify: inter-word;
   }
 
   h1,
@@ -35,8 +35,14 @@ defineProps({
   pre,
   ul,
   ol {
-    margin-bottom: 1rem;
+    margin-bottom: 1.8rem;
     color: var(--text-light);
+  }
+
+  p, ul, ol, blockquote {
+    letter-spacing: .3px;
+    font-size: 1rem;
+    line-height: 1.5rem;
   }
 
   li {
@@ -46,10 +52,12 @@ defineProps({
 
   code {
     width: 100% !important;
-    font-size: 0.875rem;
+    font-size: .95rem;
     line-height: 1.3rem;
     background-color: rgb(225 225 225);
-    padding: 4px;
+    border: 1px solid #bebebe;
+    padding-inline: 4px;
+    padding-block: 1px;
   }
 
   pre {
@@ -65,6 +73,7 @@ defineProps({
       padding: 0;
       margin: 0;
       background-color: transparent;
+      border: none;
     }
   }
 
@@ -112,7 +121,7 @@ defineProps({
 body[theme-dark] {
   .blog-content-data {
     code {
-      background-color: rgb(54 54 54);
+      background-color: rgb(42, 42, 42);
       color: var(--text-dark);
     }
 

--- a/src/components/detail/ContentData.vue
+++ b/src/components/detail/ContentData.vue
@@ -39,8 +39,11 @@ defineProps({
     color: var(--text-light);
   }
 
-  p, ul, ol, blockquote {
-    letter-spacing: .3px;
+  p,
+  ul,
+  ol,
+  blockquote {
+    letter-spacing: 0.3px;
     font-size: 1rem;
     line-height: 1.5rem;
   }
@@ -52,7 +55,7 @@ defineProps({
 
   code {
     width: 100% !important;
-    font-size: .95rem;
+    font-size: 0.95rem;
     line-height: 1.3rem;
     background-color: rgb(225 225 225);
     border: 1px solid #bebebe;
@@ -121,7 +124,7 @@ defineProps({
 body[theme-dark] {
   .blog-content-data {
     code {
-      background-color: rgb(42, 42, 42);
+      background-color: rgb(42 42 42);
       color: var(--text-dark);
     }
 

--- a/src/helpers/constants.js
+++ b/src/helpers/constants.js
@@ -2,7 +2,8 @@ export const FONT_MAP = [
   { name: "Lato", class: "font-lato" },
   { name: "Roboto", class: "font-roboto" },
   { name: "Poppins", class: "font-poppins" },
-  { name: "Open Sans", class: "font-open-sans" }
+  { name: "Open Sans", class: "font-open-sans" },
+  { name: "Inter", class: "font-inter" }
 ]
 
 export const THEME_ARRAY = ["light", "dark"]
@@ -11,7 +12,7 @@ export const HOME_VIEW_MODES = ["grid", "list"]
 
 export const DEFAULT_HOME_VIEW_MODE = "list"
 
-export const DEFAULT_FONT = FONT_MAP[0].name
+export const DEFAULT_FONT = FONT_MAP[4].name
 
 export const DEFAULT_THEME = THEME_ARRAY[0]
 

--- a/src/styles/blogPeek.scss
+++ b/src/styles/blogPeek.scss
@@ -63,6 +63,7 @@
     .blog-title {
       font-size: 1.2rem;
       font-weight: 500;
+
       &:hover {
         color: rgb(28 75 28);
       }
@@ -75,8 +76,8 @@
         font-size: 0.875rem;
         margin: 0 0.2rem;
         padding: 0.2rem;
-        background-color: rgb(223, 223, 223);
-        letter-spacing: .5px;
+        background-color: rgb(223 223 223);
+        letter-spacing: 0.5px;
       }
     }
   }

--- a/src/styles/blogPeek.scss
+++ b/src/styles/blogPeek.scss
@@ -61,6 +61,8 @@
     padding: 0.5rem 1rem;
 
     .blog-title {
+      font-size: 1.2rem;
+      font-weight: 500;
       &:hover {
         color: rgb(28 75 28);
       }
@@ -71,10 +73,10 @@
 
       .tag-item {
         font-size: 0.875rem;
-        font-style: italic;
         margin: 0 0.2rem;
         padding: 0.2rem;
-        background-color: rgb(233 233 233);
+        background-color: rgb(223, 223, 223);
+        letter-spacing: .5px;
       }
     }
   }

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -2,6 +2,7 @@
 @import "https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap";
 @import "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap";
 @import "https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap";
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
 
 * {
   margin: 0;
@@ -28,6 +29,10 @@ p {
 
 .font-lato {
   font-family: Lato, sans-serif;
+}
+
+.font-inter {
+  font-family: Inter, sans-serif;
 }
 
 a {

--- a/src/styles/util.scss
+++ b/src/styles/util.scss
@@ -2,7 +2,7 @@
 @import "https://fonts.googleapis.com/css2?family=Poppins:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap";
 @import "https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,500;0,600;0,700;1,300;1,400;1,500;1,600;1,700&display=swap";
 @import "https://fonts.googleapis.com/css2?family=Lato:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap";
-@import url('https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap');
+@import "https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800;900&display=swap";
 
 * {
   margin: 0;


### PR DESCRIPTION
With this PR, a new font [InterFont](https://fonts.google.com/specimen/Inter) is added to the font menu.

Also, the new Inter font is set as the default font.
Plus, some adjustments for the text css in the detail view.

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
