### PR TITLE
[lint] update the rule to allow space separated multiple CSS indentifiers

### DIFF
--- a/src/components/detail/ContentData.vue
+++ b/src/components/detail/ContentData.vue
@@ -25,24 +25,12 @@ defineProps({
     text-justify: inter-word;
   }
 
-  h1,
-  h2,
-  h3,
-  h4,
-  h5,
-  h6,
-  p,
-  pre,
-  ul,
-  ol {
+  h1, h2, h3, h4, h5, h6, p, pre, ul, ol {
     margin-bottom: 1.8rem;
     color: var(--text-light);
   }
 
-  p,
-  ul,
-  ol,
-  blockquote {
+  p, ul, ol, blockquote {
     letter-spacing: 0.3px;
     font-size: 1rem;
     line-height: 1.5rem;
@@ -123,15 +111,13 @@ defineProps({
   table {
     border: 1px solid black;
 
-    td,
-    th {
+    td, th {
       border: 1px solid black;
       border-radius: 0;
       padding: 0.5rem;
     }
 
-    thead,
-    tr:nth-child(even) {
+    thead, tr:nth-child(even) {
       background-color: #e2e0e0b4;
     }
   }
@@ -156,28 +142,18 @@ body[theme-dark] {
       }
     }
 
-    h1,
-    h2,
-    h3,
-    h4,
-    h5,
-    h6,
-    p,
-    ul,
-    li {
+    h1, h2, h3, h4, h5, h6, p, ul, li {
       color: var(--text-dark);
     }
 
     table {
       border-color: grey;
 
-      td,
-      th {
+      td, th {
         border-color: grey;
       }
 
-      thead,
-      tr:nth-child(even) {
+      thead, tr:nth-child(even) {
         background-color: rgb(39 38 38);
       }
     }

--- a/src/styles/home.scss
+++ b/src/styles/home.scss
@@ -67,8 +67,7 @@
       width: 36px;
       padding-top: 3px;
 
-      &.filtering,
-      &.sorting {
+      &.filtering, &.sorting {
         border: 1px solid rgb(53 53 53);
       }
     }
@@ -123,8 +122,7 @@ body[theme-dark] {
     }
 
     &--search button {
-      &.filtering,
-      &.sorting {
+      &.filtering, &.sorting {
         border: 1px solid rgb(149 149 149);
       }
     }

--- a/stylelint.conf.js
+++ b/stylelint.conf.js
@@ -9,6 +9,10 @@ module.exports = {
     files: ["**/*.scss"],
     customSyntax: "postcss-scss"
   }],
+  rules: {
+    "selector-list-comma-space-after": "always",
+    "selector-list-comma-newline-after": null
+  },
   ignoreFiles: [
     "**/*.js",
     "**/*.md",


### PR DESCRIPTION
With this,,,we do not have to go to the next line if we wish to add comma in the CSS definitions.

---
Signed-off-by: Kiran Parajuli <kiranparajuli589@gmail.com>
