### PR TITLE
Fixed a typo on the footer component

### DIFF
--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -24,7 +24,7 @@
       <div class="f-line">
         <i>
           <span><mdi-format-quote-open class="quote-icon" /></span>
-          We develop <span>SOFTWARE</span> that matters. We develop <span>STAFF</span> to reach their peek potential.
+          We develop <span>SOFTWARE</span> that matters. We develop <span>STAFF</span> so they reach their peak potential.
           <span><mdi-format-quote-close class="quote-icon" /></span>
         </i>
       </div>


### PR DESCRIPTION
There is a typo on the footer, this PR will fix that. 

Previously, it was: `We develop SOFTWARE that matters. We develop STAFF to reach their peek potential. `

It will be replaced by: `We develop SOFTWARE that matters. We develop STAFF so they reach their peak potential. `