### PR TITLE
use matomo for tracking

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     },
     "dependencies": {
         "@iconify-json/mdi": "^1.1.24",
+        "@jonkoops/matomo-tracker": "^0.7.0",
         "dompurify": "^2.3.8",
         "highlight.js": "^11.6.0",
         "marked": "^4.0.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2,6 +2,7 @@ lockfileVersion: 5.4
 
 specifiers:
   '@iconify-json/mdi': ^1.1.24
+  '@jonkoops/matomo-tracker': ^0.7.0
   '@vitejs/plugin-vue': ^2.3.3
   dompurify: ^2.3.8
   eslint: ^8.18.0
@@ -28,6 +29,7 @@ specifiers:
 
 dependencies:
   '@iconify-json/mdi': 1.1.24
+  '@jonkoops/matomo-tracker': 0.7.0
   dompurify: 2.3.8
   highlight.js: 11.6.0
   marked: 4.0.17
@@ -165,6 +167,10 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: true
+
+  /@jonkoops/matomo-tracker/0.7.0:
+    resolution: {integrity: sha512-ppCXiDaVytTQOP6hNZIBwjUph5IrGgDoQw4IF5sBoA3PBpMAc5tWtPExbVWTR5pJWpTcp11dv2M83n9pm7LpeQ==}
+    dev: false
 
   /@nodelib/fs.scandir/2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}

--- a/src/helpers/tracker.js
+++ b/src/helpers/tracker.js
@@ -1,0 +1,6 @@
+import MatomoTracker from "@jonkoops/matomo-tracker"
+
+export const tracker = new MatomoTracker({
+  urlBase: "https://www.jankaritech.com/piwik",
+  siteId: 2
+})

--- a/src/views/HomeView.vue
+++ b/src/views/HomeView.vue
@@ -115,6 +115,7 @@ import { getPeekData } from "../helpers/markdown"
 import getImageUrl from "../helpers/images"
 import { Storage } from "../helpers/storage"
 import { SORT_OPTIONS, FILTER_OPTIONS } from "../helpers/constants"
+import { tracker } from "../helpers/tracker"
 
 const { currentRoute, push } = useRouter()
 
@@ -127,6 +128,7 @@ const homeViewMode = ref(null)
 
 onMounted(async () => {
   init()
+  tracker.trackPageView()
 })
 
 const init = () => {

--- a/src/views/PostView.vue
+++ b/src/views/PostView.vue
@@ -20,6 +20,7 @@ import ContentInfo from "../components/detail/ContentInfo"
 import ContentData from "../components/detail/ContentData"
 import ContentSidebar from "../components/detail/ContentSidebar"
 import FootSection from "../components/detail/FootSection"
+import { tracker } from "../helpers/tracker"
 
 const { currentRoute, push } = useRouter()
 const { modules } = useMarkdown()
@@ -30,6 +31,7 @@ const peekData = ref(null)
 
 onMounted(() => {
   loadMarkdown()
+  tracker.trackPageView()
 })
 
 watch(currentRoute, () => {


### PR DESCRIPTION
to know how many reads we have we can use matomo for tracking
because we have a single page app, the url is always the same but the title helps to seperate the different posts
