### PR TITLE
[chore] fix the tags presentations in the peek card

### DIFF
--- a/src/components/BlogPeek.vue
+++ b/src/components/BlogPeek.vue
@@ -45,12 +45,12 @@
         {{ title }}
       </div>
       <div class="tags">
-        <span v-for="(item, index) in tags"
+        <div v-for="(item, index) in tags"
           :key="index"
           class="tag-item"
         >
           #&nbsp;{{item}}
-        </span>
+        </div>
       </div>
     </div>
     <div v-if="!detailView" class="blog-peek--footer">

--- a/src/styles/blogPeek.scss
+++ b/src/styles/blogPeek.scss
@@ -75,11 +75,13 @@
 
     .tags {
       padding-top: 0.5rem;
+      display: flex;
+      flex-wrap: wrap;
 
       .tag-item {
         font-size: 0.875rem;
-        margin: 0 0.2rem;
-        padding: 0.2rem;
+        margin: 0.2rem;
+        padding: 0.2rem 0.3rem;
         background-color: rgb(223 223 223);
         letter-spacing: 0.5px;
       }


### PR DESCRIPTION
# Description
Add breathing spaces for the tag items in the peek card

# Before
![Screenshot from 2022-12-12 20-26-54](https://user-images.githubusercontent.com/39373750/207073829-be35c5c9-2cc8-4890-acf2-c7b411d1fab3.png)

# After
![Screenshot from 2022-12-12 20-27-07](https://user-images.githubusercontent.com/39373750/207074027-0d567a11-f2e4-4300-ab0a-ce14250fb17e.png)


