### PR TITLE
Text/div overflowing when using long text fixed

### DIFF
--- a/src/components/detail/ContentData.vue
+++ b/src/components/detail/ContentData.vue
@@ -14,6 +14,7 @@ defineProps({
 <style lang="scss">
 .blog-content-data {
   flex: 65%;
+  max-width: 65%;
   padding: 0 1rem;
 
   @media only screen and (max-width: 768px) {


### PR DESCRIPTION
Table of Content didn't have enough space
[Blog page](https://blog.jankaritech.com/#/blog/Performance%20Testing%20with%20Locust/Locust%20-%2003%20-%20Setup%20Your%20System)

[Screencast from 9-6-23 03:00:09 अपराह्न +0545.webm](https://github.com/JankariTech/blog/assets/122071597/33c4a7c6-3ca8-4417-940a-a61b1e84a7cf)




