### PR TITLE
[Docs] Updated node and pnpm min version requirement in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ A beautiful blogging platform for the JankariTech peoples.
 ## Installation
 
 1. Requirements
-   - [NodeJS (>16.0.0)](https://nodejs.org/en/download/)
-   - [pnpm (>7.0.0)](https://pnpm.io/installation)
+   - [NodeJS (>20.0.0)](https://nodejs.org/en/download/)
+   - [pnpm (>9.0.0)](https://pnpm.io/installation)
 
 2. Install Dependencies
     ```bash


### PR DESCRIPTION
The minimum version of node is changed to `>20` and pnpm is changed to `>9`. The CI needs these versions after the PR https://github.com/JankariTech/blog/pull/152 